### PR TITLE
chore: add Emdash notification and stop hooks to local settings

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,5 +9,27 @@
       "WebFetch(domain:github.com)"
     ],
     "deny": []
+  },
+  "hooks": {
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -sf -X POST -H \"Content-Type: application/json\" -H \"X-Emdash-Token: $EMDASH_HOOK_TOKEN\" -H \"X-Emdash-Pty-Id: $EMDASH_PTY_ID\" -H \"X-Emdash-Event-Type: notification\" -d @- \"http://127.0.0.1:$EMDASH_HOOK_PORT/hook\" || true"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -sf -X POST -H \"Content-Type: application/json\" -H \"X-Emdash-Token: $EMDASH_HOOK_TOKEN\" -H \"X-Emdash-Pty-Id: $EMDASH_PTY_ID\" -H \"X-Emdash-Event-Type: stop\" -d @- \"http://127.0.0.1:$EMDASH_HOOK_PORT/hook\" || true"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Adds `Notification` and `Stop` Claude Code hooks to `.claude/settings.local.json`
- Both hooks POST event data to a local Emdash HTTP server for IDE/terminal integration
- Also fixes missing newline at end of file

## Test plan

- [ ] Verify Emdash integration receives notification and stop events during a Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)