### PR TITLE
Replace Math.random() with crypto.randomUUID() for screenshot filenames

### DIFF
--- a/src/__tests__/storage.test.ts
+++ b/src/__tests__/storage.test.ts
@@ -51,8 +51,12 @@ describe("StorageService", () => {
       const fileName1 = storageService.generateFileName();
       const fileName2 = storageService.generateFileName();
 
-      expect(fileName1).toMatch(/^screenshot-\d+-[a-z0-9]+\.png$/);
-      expect(fileName2).toMatch(/^screenshot-\d+-[a-z0-9]+\.png$/);
+      expect(fileName1).toMatch(
+        /^screenshot-\d+-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.png$/,
+      );
+      expect(fileName2).toMatch(
+        /^screenshot-\d+-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.png$/,
+      );
       expect(fileName1).not.toBe(fileName2);
     });
   });

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -7,6 +7,7 @@ import {
   GetObjectCommand,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { randomUUID } from "crypto";
 import { Config } from "../config";
 import {
   s3OperationDuration,
@@ -179,7 +180,6 @@ export class StorageService {
 
   generateFileName(): string {
     const timestamp = Date.now();
-    const random = Math.random().toString(36).substring(2, 15);
-    return `screenshot-${timestamp}-${random}.png`;
+    return `screenshot-${timestamp}-${randomUUID()}.png`;
   }
 }


### PR DESCRIPTION
## Summary

Replaces the non-cryptographic `Math.random()`-based suffix in generated screenshot filenames with `crypto.randomUUID()` in `src/services/storage.ts`.

## Changes

- `src/services/storage.ts`: `generateFileName()` now uses `crypto.randomUUID()` instead of `Math.random().toString(36).substring(2, 15)`, producing a version 4 UUID suffix for higher uniqueness and collision resistance.
- `src/__tests__/storage.test.ts`: updated filename assertions to validate the UUID format (`screenshot-<timestamp>-<uuid>.png`); uniqueness check remains.

## Testing

- Unit tests updated to match the new filename format and still pass the uniqueness assertion.

closes #62 