### PR TITLE
Consolidate tracing and metrics into a single traceAndTrack helper

### DIFF
--- a/src/__tests__/observability.test.ts
+++ b/src/__tests__/observability.test.ts
@@ -1,0 +1,126 @@
+import { Histogram } from "prom-client";
+import { traceAndTrack } from "../observability";
+
+describe("traceAndTrack", () => {
+  const makeHistogram = (labelNames: string[] = ["status"]) =>
+    new Histogram({
+      name: `test_histogram_${Math.random().toString(36).slice(2)}`,
+      help: "test histogram",
+      labelNames,
+      registers: [],
+    });
+
+  it("returns the operation's result when no histogram is given", async () => {
+    const result = await traceAndTrack({ name: "op" }, async () => "value");
+
+    expect(result).toBe("value");
+  });
+
+  it("propagates the operation's error when no histogram is given", async () => {
+    await expect(
+      traceAndTrack({ name: "op" }, async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+  });
+
+  it("records the histogram with successLabels on success", async () => {
+    const histogram = makeHistogram();
+
+    const result = await traceAndTrack(
+      {
+        name: "op",
+        histogram,
+        successLabels: { status: "success" },
+        errorLabels: { status: "error" },
+      },
+      async () => "value",
+    );
+
+    expect(result).toBe("value");
+    const metric = await histogram.get();
+    const sample = metric.values.find((v) => v.labels.status === "success");
+    expect(sample).toBeDefined();
+  });
+
+  it("records the histogram with errorLabels and rethrows on error", async () => {
+    const histogram = makeHistogram();
+
+    await expect(
+      traceAndTrack(
+        {
+          name: "op",
+          histogram,
+          successLabels: { status: "success" },
+          errorLabels: { status: "error" },
+        },
+        async () => {
+          throw new Error("boom");
+        },
+      ),
+    ).rejects.toThrow("boom");
+
+    const metric = await histogram.get();
+    const errorSample = metric.values.find((v) => v.labels.status === "error");
+    expect(errorSample).toBeDefined();
+  });
+
+  it("uses base labels as-is when no success/error labels are given", async () => {
+    const histogram = makeHistogram(["operation"]);
+
+    await traceAndTrack(
+      { name: "op", histogram, labels: { operation: "upload" } },
+      async () => "value",
+    );
+
+    const metric = await histogram.get();
+    const sample = metric.values.find((v) => v.labels.operation === "upload");
+    expect(sample).toBeDefined();
+  });
+
+  it("does not fail the operation when the histogram labels are invalid on success", async () => {
+    const histogram = makeHistogram(["status"]);
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const result = await traceAndTrack(
+      {
+        name: "op",
+        histogram,
+        // "unexpected" isn't a declared label, so prom-client will throw internally
+        successLabels: { status: "success", unexpected: "label" },
+      },
+      async () => "value",
+    );
+
+    expect(result).toBe("value");
+    expect(consoleErrorSpy).toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("still rethrows the operation's error when the histogram labels are invalid", async () => {
+    const histogram = makeHistogram(["status"]);
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    await expect(
+      traceAndTrack(
+        {
+          name: "op",
+          histogram,
+          errorLabels: { status: "error", unexpected: "label" },
+        },
+        async () => {
+          throw new Error("boom");
+        },
+      ),
+    ).rejects.toThrow("boom");
+
+    expect(consoleErrorSpy).toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,6 +39,10 @@ export const Config = {
     region: process.env.S3_REGION || "us-east-1",
   },
   presignedUrlExpiry: parseInt(process.env.PRESIGNED_URL_EXPIRY || "3600", 10),
+  playwright: {
+    chromiumExecutablePath:
+      process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH || undefined,
+  },
   rateLimit: {
     windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS || "60000", 10),
     max: parseInt(process.env.RATE_LIMIT_MAX || "30", 10),

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -1,0 +1,40 @@
+import { Histogram } from "prom-client";
+import { tracingUtils } from "./tracing";
+
+export interface TraceAndTrackOptions {
+  // Span/operation name, shared by the trace and (if present) the histogram timer
+  name: string;
+  attributes?: Record<string, any>;
+  histogram?: Histogram<string>;
+  labels?: Record<string, string | number>;
+  // Extra labels merged in on success/error, e.g. a dynamic `status` label
+  successLabels?: Record<string, string | number>;
+  errorLabels?: Record<string, string | number>;
+}
+
+// Wraps an operation with a trace span and, if a histogram is provided, a
+// duration timer whose labels can be refined based on the operation's outcome.
+export async function traceAndTrack<T>(
+  options: TraceAndTrackOptions,
+  operation: () => Promise<T>,
+): Promise<T> {
+  return tracingUtils.traceOperation(
+    options.name,
+    async () => {
+      if (!options.histogram) {
+        return operation();
+      }
+
+      const end = options.histogram.startTimer(options.labels);
+      try {
+        const result = await operation();
+        end(options.successLabels);
+        return result;
+      } catch (error) {
+        end(options.errorLabels);
+        throw error;
+      }
+    },
+    options.attributes,
+  );
+}

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -12,6 +12,34 @@ export interface TraceAndTrackOptions {
   errorLabels?: Record<string, string | number>;
 }
 
+type TimerEnd = (labels?: Record<string, string | number>) => number;
+
+// Metrics are best-effort: a labeling mistake (e.g. a label not declared on
+// the histogram) must not fail the operation it's measuring.
+function startTimer(
+  histogram: Histogram<string>,
+  labels?: Record<string, string | number>,
+): TimerEnd | null {
+  try {
+    return histogram.startTimer(labels);
+  } catch (error) {
+    console.error("Failed to start histogram timer:", error);
+    return null;
+  }
+}
+
+function endTimer(
+  end: TimerEnd | null,
+  labels?: Record<string, string | number>,
+): void {
+  if (!end) return;
+  try {
+    end(labels);
+  } catch (error) {
+    console.error("Failed to record histogram duration:", error);
+  }
+}
+
 // Wraps an operation with a trace span and, if a histogram is provided, a
 // duration timer whose labels can be refined based on the operation's outcome.
 export async function traceAndTrack<T>(
@@ -25,13 +53,13 @@ export async function traceAndTrack<T>(
         return operation();
       }
 
-      const end = options.histogram.startTimer(options.labels);
+      const end = startTimer(options.histogram, options.labels);
       try {
         const result = await operation();
-        end(options.successLabels);
+        endTimer(end, options.successLabels);
         return result;
       } catch (error) {
-        end(options.errorLabels);
+        endTimer(end, options.errorLabels);
         throw error;
       }
     },

--- a/src/routes/screenshot.ts
+++ b/src/routes/screenshot.ts
@@ -12,9 +12,8 @@ import {
   concurrentRequests,
   metabaseUrlGeneration,
   metabaseUrlErrors,
-  metricsUtils,
 } from "../metrics";
-import { tracingUtils } from "../tracing";
+import { traceAndTrack } from "../observability";
 
 const router = Router();
 const screenshotService = new ScreenshotService();
@@ -48,19 +47,20 @@ router.post(
       }
 
       // Track Metabase URL generation with tracing
-      const embedUrl = await tracingUtils.traceOperation(
-        "metabase.generate_embed_url",
+      const embedUrl = await traceAndTrack(
+        {
+          name: "metabase.generate_embed_url",
+          histogram: metabaseUrlGeneration,
+          successLabels: { status: "success" },
+          errorLabels: { status: "error" },
+          attributes: { "metabase.questionId": request.questionId },
+        },
         async () => {
           try {
-            return await metricsUtils.trackDuration(
-              metabaseUrlGeneration,
-              { status: "success" },
-              async () =>
-                generateMetabaseEmbedUrl({
-                  questionId: request.questionId,
-                  params: request.params,
-                }),
-            );
+            return await generateMetabaseEmbedUrl({
+              questionId: request.questionId,
+              params: request.params,
+            });
           } catch (metabaseError: unknown) {
             const errorMessage =
               metabaseError instanceof Error
@@ -71,14 +71,9 @@ router.post(
                 ? "missing_secret"
                 : "unknown",
             });
-            metabaseUrlGeneration.observe(
-              { status: "error" },
-              Date.now() / 1000,
-            );
             throw metabaseError;
           }
         },
-        { "metabase.questionId": request.questionId },
       );
 
       const screenshot = await screenshotService.takeScreenshot(

--- a/src/services/screenshot.ts
+++ b/src/services/screenshot.ts
@@ -29,9 +29,8 @@ export class ScreenshotService {
         };
 
         // Use system Chromium if available (for Docker deployment)
-        if (process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH) {
-          launchOptions.executablePath =
-            process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+        if (Config.playwright.chromiumExecutablePath) {
+          launchOptions.executablePath = Config.playwright.chromiumExecutablePath;
         }
 
         this.browser = await chromium.launch(launchOptions);

--- a/src/services/screenshot.ts
+++ b/src/services/screenshot.ts
@@ -6,9 +6,8 @@ import {
   screenshotDuration,
   screenshotErrors,
   pageLoadDuration,
-  metricsUtils,
 } from "../metrics";
-import { tracingUtils } from "../tracing";
+import { traceAndTrack } from "../observability";
 import { logger } from "../logger";
 import { Config } from "../config";
 
@@ -16,49 +15,45 @@ export class ScreenshotService {
   private browser: Browser | null = null;
 
   async initialize(): Promise<void> {
-    await tracingUtils.traceOperation(
-      "browser.initialize",
-      async () => {
-        await metricsUtils.trackDuration(
-          browserLifecycle,
-          { operation: "startup" },
-          async () => {
-            const launchOptions: LaunchOptions = {
-              headless: true,
-              args: ["--no-sandbox", "--disable-setuid-sandbox"],
-            };
-
-            // Use system Chromium if available (for Docker deployment)
-            if (process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH) {
-              launchOptions.executablePath =
-                process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
-            }
-
-            this.browser = await chromium.launch(launchOptions);
-            activeBrowsers.inc();
-          },
-        );
+    await traceAndTrack(
+      {
+        name: "browser.initialize",
+        histogram: browserLifecycle,
+        labels: { operation: "startup" },
+        attributes: { "browser.type": "chromium" },
       },
-      { "browser.type": "chromium" },
+      async () => {
+        const launchOptions: LaunchOptions = {
+          headless: true,
+          args: ["--no-sandbox", "--disable-setuid-sandbox"],
+        };
+
+        // Use system Chromium if available (for Docker deployment)
+        if (process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH) {
+          launchOptions.executablePath =
+            process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+        }
+
+        this.browser = await chromium.launch(launchOptions);
+        activeBrowsers.inc();
+      },
     );
   }
 
   async close(): Promise<void> {
     if (this.browser) {
-      await tracingUtils.traceOperation(
-        "browser.close",
-        async () => {
-          await metricsUtils.trackDuration(
-            browserLifecycle,
-            { operation: "shutdown" },
-            async () => {
-              await this.browser!.close();
-              this.browser = null;
-              activeBrowsers.dec();
-            },
-          );
+      await traceAndTrack(
+        {
+          name: "browser.close",
+          histogram: browserLifecycle,
+          labels: { operation: "shutdown" },
+          attributes: { "browser.type": "chromium" },
         },
-        { "browser.type": "chromium" },
+        async () => {
+          await this.browser!.close();
+          this.browser = null;
+          activeBrowsers.dec();
+        },
       );
     }
   }
@@ -72,163 +67,142 @@ export class ScreenshotService {
       throw new Error("Screenshot service not initialized");
     }
 
-    return await tracingUtils.traceOperation(
-      "screenshot.generate",
+    return await traceAndTrack(
+      {
+        name: "screenshot.generate",
+        histogram: screenshotDuration,
+        successLabels: { status: "success" },
+        errorLabels: { status: "error" },
+        attributes: {
+          "request.questionId": request.questionId,
+          "request.width": request.width || 1920,
+          "request.height": request.height || 1080,
+        },
+      },
       async () => {
-        return await metricsUtils.trackDuration(
-          screenshotDuration,
-          { status: "unknown" },
-          async () => {
-            const page: Page = await this.browser!.newPage();
+        const page: Page = await this.browser!.newPage();
 
-            try {
-              // Use much shorter waits when running tests to avoid long timeouts on synthetic pages
-              const isTestEnv = Config.nodeEnv === "test";
-              const spinnerHiddenTimeout = isTestEnv ? 500 : 30000;
-              const vizContentTimeout = isTestEnv ? 200 : 15000;
-              const finalRenderDelayMs = isTestEnv ? 50 : 1000;
+        try {
+          // Use much shorter waits when running tests to avoid long timeouts on synthetic pages
+          const isTestEnv = Config.nodeEnv === "test";
+          const spinnerHiddenTimeout = isTestEnv ? 500 : 30000;
+          const vizContentTimeout = isTestEnv ? 200 : 15000;
+          const finalRenderDelayMs = isTestEnv ? 50 : 1000;
 
-              await tracingUtils.traceOperation(
-                "screenshot.setup_viewport",
-                async () => {
-                  await page.setViewportSize({
-                    width: request.width || 1920,
-                    height: request.height || 1080,
+          await traceAndTrack(
+            {
+              name: "screenshot.setup_viewport",
+              attributes: {
+                "viewport.width": request.width || 1920,
+                "viewport.height": request.height || 1080,
+              },
+            },
+            async () => {
+              await page.setViewportSize({
+                width: request.width || 1920,
+                height: request.height || 1080,
+              });
+            },
+          );
+
+          // Track page load with tracing
+          await traceAndTrack(
+            {
+              name: "screenshot.page_load",
+              histogram: pageLoadDuration,
+              successLabels: { status: "success" },
+              errorLabels: { status: "error" },
+              attributes: {
+                "page.url": embedUrl,
+                "page.selector": "div[data-testid=embed-frame]",
+              },
+            },
+            async () => {
+              await page.goto(embedUrl, {
+                timeout: 30000,
+                waitUntil: "networkidle",
+              });
+
+              // 1. Wait for embed frame (shorter timeout)
+              await page.waitForSelector("div[data-testid=embed-frame]", {
+                timeout: 15000,
+              });
+
+              // 2. Wait for loading spinner to disappear (only if it exists)
+              const spinnerHandle = await page.$(".LoadingSpinner");
+              if (spinnerHandle) {
+                await page
+                  .waitForSelector(".LoadingSpinner", {
+                    state: "hidden",
+                    timeout: spinnerHiddenTimeout,
+                  })
+                  .catch((error) => {
+                    logger.warn(
+                      {
+                        type: "screenshot_wait_warning",
+                        selector: ".LoadingSpinner",
+                        state: "hidden",
+                        timeout: spinnerHiddenTimeout,
+                        error: error.message,
+                      },
+                      "LoadingSpinner wait timeout - continuing",
+                    );
                   });
-                },
-                {
-                  "viewport.width": request.width || 1920,
-                  "viewport.height": request.height || 1080,
-                },
-              );
-
-              // Track page load with tracing
-              await tracingUtils.traceOperation(
-                "screenshot.page_load",
-                async () => {
-                  await metricsUtils.trackDuration(
-                    pageLoadDuration,
-                    { status: "unknown" },
-                    async () => {
-                      await page.goto(embedUrl, {
-                        timeout: 30000,
-                        waitUntil: "networkidle",
-                      });
-
-                      // 1. Wait for embed frame (shorter timeout)
-                      await page.waitForSelector(
-                        "div[data-testid=embed-frame]",
-                        {
-                          timeout: 15000,
-                        },
-                      );
-
-                      // 2. Wait for loading spinner to disappear (only if it exists)
-                      const spinnerHandle = await page.$(".LoadingSpinner");
-                      if (spinnerHandle) {
-                        await page
-                          .waitForSelector(".LoadingSpinner", {
-                            state: "hidden",
-                            timeout: spinnerHiddenTimeout,
-                          })
-                          .catch((error) => {
-                            logger.warn(
-                              {
-                                type: "screenshot_wait_warning",
-                                selector: ".LoadingSpinner",
-                                state: "hidden",
-                                timeout: spinnerHiddenTimeout,
-                                error: error.message,
-                              },
-                              "LoadingSpinner wait timeout - continuing",
-                            );
-                          });
-                      }
-
-                      // 3. Wait briefly for visualization content; don't stall long on synthetic/test pages
-                      await page
-                        .waitForSelector(
-                          "svg, canvas, .visualization, .DashCard",
-                          {
-                            timeout: vizContentTimeout,
-                          },
-                        )
-                        .catch((error) => {
-                          logger.warn(
-                            {
-                              type: "screenshot_wait_warning",
-                              selector:
-                                "svg, canvas, .visualization, .DashCard",
-                              timeout: vizContentTimeout,
-                              error: error.message,
-                            },
-                            "Visualization elements not found in time - continuing",
-                          );
-                        });
-
-                      // 4. Brief pause for final rendering
-                      await page.waitForTimeout(finalRenderDelayMs);
-                    },
-                  );
-                },
-                {
-                  "page.url": embedUrl,
-                  "page.selector": "div[data-testid=embed-frame]",
-                },
-              );
-
-              const screenshot = await tracingUtils.traceOperation(
-                "screenshot.capture",
-                async () => {
-                  return await page.screenshot({
-                    type: "png",
-                    fullPage: true,
-                  });
-                },
-                { "screenshot.type": "png", "screenshot.fullPage": true },
-              );
-
-              // Update success status after successful completion
-              screenshotDuration.observe(
-                { status: "success" },
-                Date.now() / 1000,
-              );
-              pageLoadDuration.observe(
-                { status: "success" },
-                Date.now() / 1000,
-              );
-
-              return screenshot;
-            } catch (error) {
-              // Track different types of errors
-              if (error instanceof Error) {
-                if (error.message.includes("timeout")) {
-                  screenshotErrors.inc({ error_type: "timeout" });
-                } else if (error.message.includes("selector")) {
-                  screenshotErrors.inc({ error_type: "selector_not_found" });
-                } else {
-                  screenshotErrors.inc({ error_type: "unknown" });
-                }
               }
 
-              // Update failure status
-              screenshotDuration.observe(
-                { status: "error" },
-                Date.now() / 1000,
-              );
-              pageLoadDuration.observe({ status: "error" }, Date.now() / 1000);
+              // 3. Wait briefly for visualization content; don't stall long on synthetic/test pages
+              await page
+                .waitForSelector("svg, canvas, .visualization, .DashCard", {
+                  timeout: vizContentTimeout,
+                })
+                .catch((error) => {
+                  logger.warn(
+                    {
+                      type: "screenshot_wait_warning",
+                      selector: "svg, canvas, .visualization, .DashCard",
+                      timeout: vizContentTimeout,
+                      error: error.message,
+                    },
+                    "Visualization elements not found in time - continuing",
+                  );
+                });
 
-              throw error;
-            } finally {
-              await page.close();
+              // 4. Brief pause for final rendering
+              await page.waitForTimeout(finalRenderDelayMs);
+            },
+          );
+
+          return await traceAndTrack(
+            {
+              name: "screenshot.capture",
+              attributes: {
+                "screenshot.type": "png",
+                "screenshot.fullPage": true,
+              },
+            },
+            async () => {
+              return await page.screenshot({
+                type: "png",
+                fullPage: true,
+              });
+            },
+          );
+        } catch (error) {
+          // Track different types of errors
+          if (error instanceof Error) {
+            if (error.message.includes("timeout")) {
+              screenshotErrors.inc({ error_type: "timeout" });
+            } else if (error.message.includes("selector")) {
+              screenshotErrors.inc({ error_type: "selector_not_found" });
+            } else {
+              screenshotErrors.inc({ error_type: "unknown" });
             }
-          },
-        );
-      },
-      {
-        "request.questionId": request.questionId,
-        "request.width": request.width || 1920,
-        "request.height": request.height || 1080,
+          }
+
+          throw error;
+        } finally {
+          await page.close();
+        }
       },
     );
   }

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -14,7 +14,7 @@ import {
   uploadSize,
   metricsUtils,
 } from "../metrics";
-import { tracingUtils } from "../tracing";
+import { traceAndTrack } from "../observability";
 
 interface ExtendedS3ClientConfig extends S3ClientConfig {
   endpoint?: string;
@@ -103,24 +103,28 @@ export class StorageService {
     // Record upload size
     uploadSize.observe(buffer.length);
 
-    await tracingUtils.traceOperation(
-      "s3.upload",
+    await traceAndTrack(
+      {
+        name: "s3.upload",
+        histogram: s3OperationDuration,
+        labels: { operation: "upload" },
+        attributes: {
+          "s3.bucket": Config.s3.bucket,
+          "s3.key": fileName,
+          "s3.contentType": "image/png",
+          "s3.size": buffer.length,
+        },
+      },
       async () => {
         try {
-          await metricsUtils.trackDuration(
-            s3OperationDuration,
-            { operation: "upload" },
-            async () => {
-              const command = new PutObjectCommand({
-                Bucket: Config.s3.bucket,
-                Key: fileName,
-                Body: buffer,
-                ContentType: "image/png",
-              });
+          const command = new PutObjectCommand({
+            Bucket: Config.s3.bucket,
+            Key: fileName,
+            Body: buffer,
+            ContentType: "image/png",
+          });
 
-              await this.s3.send(command);
-            },
-          );
+          await this.s3.send(command);
         } catch (error: unknown) {
           const errorName =
             isAWSError(error) && error.name ? error.name : "unknown";
@@ -131,34 +135,31 @@ export class StorageService {
           throw error;
         }
       },
-      {
-        "s3.bucket": Config.s3.bucket,
-        "s3.key": fileName,
-        "s3.contentType": "image/png",
-        "s3.size": buffer.length,
-      },
     );
   }
 
   async generatePresignedUrl(fileName: string): Promise<string> {
-    return await tracingUtils.traceOperation(
-      "s3.presigned_url",
+    return await traceAndTrack(
+      {
+        name: "s3.presigned_url",
+        histogram: s3OperationDuration,
+        labels: { operation: "presigned_url" },
+        attributes: {
+          "s3.bucket": Config.s3.bucket,
+          "s3.key": fileName,
+          "s3.expiresIn": Config.presignedUrlExpiry,
+        },
+      },
       async () => {
         try {
-          return await metricsUtils.trackDuration(
-            s3OperationDuration,
-            { operation: "presigned_url" },
-            async () => {
-              const command = new GetObjectCommand({
-                Bucket: Config.s3.bucket,
-                Key: fileName,
-              });
+          const command = new GetObjectCommand({
+            Bucket: Config.s3.bucket,
+            Key: fileName,
+          });
 
-              return await getSignedUrl(this.s3, command, {
-                expiresIn: Config.presignedUrlExpiry,
-              });
-            },
-          );
+          return await getSignedUrl(this.s3, command, {
+            expiresIn: Config.presignedUrlExpiry,
+          });
         } catch (error: unknown) {
           const errorName =
             isAWSError(error) && error.name ? error.name : "unknown";
@@ -168,11 +169,6 @@ export class StorageService {
           });
           throw error;
         }
-      },
-      {
-        "s3.bucket": Config.s3.bucket,
-        "s3.key": fileName,
-        "s3.expiresIn": Config.presignedUrlExpiry,
       },
     );
   }


### PR DESCRIPTION
## Summary

Introduces a new `traceAndTrack` helper in `src/observability.ts` that wraps an operation in a trace span and (when a histogram is provided) a duration timer. Outcome-specific labels are merged via `successLabels`/`errorLabels`, replacing the previous pattern of manually calling `tracingUtils.traceOperation`, `metricsUtils.trackDuration`, and raw `observe()` calls.

## Changes

- **`src/observability.ts`** (new): `traceAndTrack<T>(options, operation)` — opens a span via `tracingUtils.traceOperation` and starts a histogram timer when `histogram` is supplied. On success it records `successLabels`, on error it records `errorLabels` and rethrows.
- **`src/routes/screenshot.ts`**: Metabase embed-URL generation now uses `traceAndTrack`, removing the manual error-path `metabaseUrlGeneration.observe(...)` call.
- **`src/services/screenshot.ts`**: `initialize`, `close`, and `takeScreenshot` now use `traceAndTrack`, including the page-load histogram (status now tracked via `successLabels`/`errorLabels` instead of manual `observe` calls).
- **`src/services/storage.ts`**: S3 upload and presigned-URL generation now use `traceAndTrack`, preserving existing error tracking/`operation` labels.

## Notes

- Manual `screenshotDuration`/`pageLoadDuration` success observations were removed in favor of the helper's timer labels.
- Error-path behavior (error counters, AWS error-name tracking, rethrow) is preserved.

## Testing

- None provided in this branch; changes are refactor-only. Existing test suite should be run to confirm no behavioral drift (e.g. `npm test` / `uv`-managed tasks as configured).

closes #60