### PR TITLE
fix: redact sensitive tokens from logs, traces, and errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,8 @@ RATE_LIMIT_MAX=30
 # Enable trust proxy when behind a reverse proxy (e.g., nginx, load balancer)
 # This allows Express to correctly read client IP from X-Forwarded-For header
 TRUST_PROXY=false
+# Tracing configuration (optional)
+# TRACING_ENABLED=false
+# OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4318/v1/traces
+# Note: Ensure OTLP endpoints use TLS (https://) in production environments for secure telemetry transmission.
+

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,7 +15,7 @@ Key conventions
 - Authentication: if `AUTH_TOKEN` is set, all `/api/*` routes require either `Authorization: Bearer <token>` or `Authorization: Basic <base64(any-username:AUTH_TOKEN)>` (only the password is validated) via `authenticateToken` middleware. Health (`/api/health`) and `/metrics` are public.
 - Errors: return `{ error: string, message: string }` (see `src/types.ts`). Avoid leaking internals; log details with `logger`.
 - Observability is first‑class:
-  - Tracing: wrap operations in `tracingUtils.traceOperation(name, fn, attrs)` (OpenTelemetry → OTLP/HTTP). Configure with `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` or `OTEL_EXPORTER_OTLP_ENDPOINT`; defaults to `http://localhost:4318/v1/traces`. Tracing is disabled in `NODE_ENV=test`.
+  - Tracing: wrap operations in `tracingUtils.traceOperation(name, fn, attrs)` (OpenTelemetry → OTLP/HTTP). Configure with `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` or `OTEL_EXPORTER_OTLP_ENDPOINT`; defaults to `http://localhost:4318/v1/traces`. Tracing is disabled in `NODE_ENV=test`. In production, OTLP endpoints should use TLS (`https://`). Never attach signed URLs to trace span attributes; errors are sanitized to redact sensitive URLs.
   - Metrics: define counters/histograms/gauges in `src/metrics.ts` and time work with `metricsUtils.trackDuration`. The `/metrics` endpoint serves Prometheus metrics.
   - Logging: use `logger` (Pino). Dev pretty‑prints; production emits JSON. Request logs skip `/metrics` and health.
 

--- a/README.md
+++ b/README.md
@@ -254,3 +254,10 @@ Environment variables:
 - `S3_BUCKET` - S3 bucket name
 - `S3_REGION` - S3 region
 - `PRESIGNED_URL_EXPIRY` - Presigned URL expiry in seconds (default: 3600, 1 hour)
+- `TRACING_ENABLED` - Enable OpenTelemetry tracing (`true`/`false`, default: `false`)
+- `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` or `OTEL_EXPORTER_OTLP_ENDPOINT` - OTLP collector traces endpoint (default: `http://localhost:4318/v1/traces`).
+
+> **Security Note on Telemetry & Tracing:**
+> - Metashot automatically redacts signed Metabase embed URLs and sensitive JWT tokens from trace span attributes, error messages, and log outputs to prevent credential leakage into telemetry backends.
+> - In production environments, OTLP collector endpoints must use TLS (`https://`) to secure telemetry data in transit.
+

--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -1,0 +1,41 @@
+import { sanitizingErrorSerializer } from "../logger";
+
+describe("sanitizingErrorSerializer", () => {
+  it("should return a JSON-serializable object retaining message and stack", () => {
+    const error = new TypeError(
+      "Navigation to http://localhost:3000/embed/question/secretToken failed",
+    );
+
+    const serialized = sanitizingErrorSerializer(error);
+    expect(serialized).not.toBeInstanceOf(Error);
+
+    const roundTripped = JSON.parse(JSON.stringify(serialized));
+    expect(roundTripped.type).toBe("TypeError");
+    expect(roundTripped.message).toBe(
+      "Navigation to http://localhost:3000/embed/question/[REDACTED] failed",
+    );
+    expect(roundTripped.stack).toEqual(expect.any(String));
+    expect(JSON.stringify(serialized)).not.toContain("secretToken");
+  });
+
+  it("should redact non-Error values without std serialization", () => {
+    const serialized = sanitizingErrorSerializer({
+      url: "http://localhost:3000/embed/question/secretToken",
+      code: 500,
+    });
+
+    expect(serialized).toEqual({
+      url: "http://localhost:3000/embed/question/[REDACTED]",
+      code: 500,
+    });
+  });
+
+  it("should not throw on circular error properties", () => {
+    const error = new Error("boom");
+    const details: Record<string, unknown> = {};
+    details.loop = details;
+    (error as unknown as Record<string, unknown>).details = details;
+
+    expect(() => sanitizingErrorSerializer(error)).not.toThrow();
+  });
+});

--- a/src/__tests__/sanitize.test.ts
+++ b/src/__tests__/sanitize.test.ts
@@ -95,5 +95,43 @@ describe("Sanitize Utility", () => {
       );
       expect(sanitized.code).toBe(500);
     });
+
+    it("should preserve the error subclass", () => {
+      const sanitized = sanitizeError(new TypeError("boom"));
+      expect(sanitized).toBeInstanceOf(TypeError);
+      expect(sanitized.constructor.name).toBe("TypeError");
+    });
+
+    it("should handle circular references in plain objects", () => {
+      const errorObj: Record<string, unknown> = {
+        url: "http://localhost:3000/embed/question/secretToken",
+      };
+      errorObj.self = errorObj;
+
+      const sanitized = sanitizeError(errorObj);
+      expect(sanitized.url).toBe(
+        "http://localhost:3000/embed/question/[REDACTED]",
+      );
+      expect(sanitized.self).toBe(sanitized);
+    });
+
+    it("should handle circular references on error properties", () => {
+      const error = new Error(
+        "Failed at http://localhost:3000/embed/question/secretToken",
+      );
+      const details: Record<string, unknown> = { owner: error };
+      details.loop = details;
+      (error as unknown as Record<string, unknown>).details = details;
+
+      const sanitized = sanitizeError(error);
+      expect(sanitized.message).toBe(
+        "Failed at http://localhost:3000/embed/question/[REDACTED]",
+      );
+      const sanitizedDetails = (
+        sanitized as unknown as Record<string, Record<string, unknown>>
+      ).details;
+      expect(sanitizedDetails.owner).toBe(sanitized);
+      expect(sanitizedDetails.loop).toBe(sanitizedDetails);
+    });
   });
 });

--- a/src/__tests__/sanitize.test.ts
+++ b/src/__tests__/sanitize.test.ts
@@ -1,0 +1,99 @@
+import { redactSensitiveInfo, sanitizeError } from "../utils/sanitize";
+
+describe("Sanitize Utility", () => {
+  describe("redactSensitiveInfo", () => {
+    it("should redact Metabase question embed URL tokens", () => {
+      const input =
+        "Error page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:3000/embed/question/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyZXNvdXJjZSI6...#bordered=true";
+      const sanitized = redactSensitiveInfo(input);
+      expect(sanitized).not.toContain("eyJhbGci");
+      expect(sanitized).toBe(
+        "Error page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:3000/embed/question/[REDACTED]#bordered=true",
+      );
+    });
+
+    it("should redact Metabase dashboard embed URL tokens", () => {
+      const input =
+        "Failed to load https://metabase.example.com/embed/dashboard/my-secret-token-123#titled=true";
+      const sanitized = redactSensitiveInfo(input);
+      expect(sanitized).not.toContain("my-secret-token-123");
+      expect(sanitized).toBe(
+        "Failed to load https://metabase.example.com/embed/dashboard/[REDACTED]#titled=true",
+      );
+    });
+
+    it("should redact standalone JWT tokens", () => {
+      const token =
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyZXNvdXJjZSI6e3F1ZXN0aW9uOjF9fQ.signature123";
+      const input = `Authentication failed for token ${token} in request`;
+      const sanitized = redactSensitiveInfo(input);
+      expect(sanitized).not.toContain(token);
+      expect(sanitized).toBe(
+        "Authentication failed for token [REDACTED] in request",
+      );
+    });
+
+    it("should redact sensitive query parameters in URLs", () => {
+      const input =
+        "Request failed: http://minio:9000/bucket/file.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=cred&X-Amz-Signature=secretSig123";
+      const sanitized = redactSensitiveInfo(input);
+      expect(sanitized).not.toContain("secretSig123");
+      expect(sanitized).not.toContain("cred");
+      expect(sanitized).toBe(
+        "Request failed: http://minio:9000/bucket/file.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=[REDACTED]&X-Amz-Signature=[REDACTED]",
+      );
+    });
+
+    it("should leave normal non-sensitive messages untouched", () => {
+      const input = "LoadingSpinner wait timeout - continuing";
+      expect(redactSensitiveInfo(input)).toBe(input);
+    });
+
+    it("should handle empty or null string gracefully", () => {
+      expect(redactSensitiveInfo("")).toBe("");
+    });
+  });
+
+  describe("sanitizeError", () => {
+    it("should sanitize Error object message and stack trace", () => {
+      const error = new Error(
+        "Navigation to http://localhost:3000/embed/question/secretToken failed",
+      );
+      error.stack =
+        "Error: Navigation to http://localhost:3000/embed/question/secretToken failed\n    at test.js:10";
+
+      const sanitized = sanitizeError(error);
+      expect(sanitized.message).not.toContain("secretToken");
+      expect(sanitized.message).toBe(
+        "Navigation to http://localhost:3000/embed/question/[REDACTED] failed",
+      );
+      expect(sanitized.stack).not.toContain("secretToken");
+      expect(sanitized.stack).toContain(
+        "http://localhost:3000/embed/question/[REDACTED]",
+      );
+    });
+
+    it("should sanitize plain error string", () => {
+      const errorStr =
+        "Error at http://localhost:3000/embed/question/secretToken";
+      const sanitized = sanitizeError(errorStr);
+      expect(sanitized).toBe(
+        "Error at http://localhost:3000/embed/question/[REDACTED]",
+      );
+    });
+
+    it("should sanitize nested error object fields", () => {
+      const errorObj = {
+        details: {
+          url: "http://localhost:3000/embed/question/secretToken",
+        },
+        code: 500,
+      };
+      const sanitized = sanitizeError(errorObj);
+      expect(sanitized.details.url).toBe(
+        "http://localhost:3000/embed/question/[REDACTED]",
+      );
+      expect(sanitized.code).toBe(500);
+    });
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,7 +20,8 @@ export const Config = {
       parseBoolean(process.env.TRACING_ENABLED) &&
       !parseBoolean(process.env.OTEL_SDK_DISABLED || undefined) &&
       (process.env.NODE_ENV || "development") !== "test",
-    // Prefer OTEL standard env vars; default to local collector (OTLP HTTP)
+    // Prefer OTEL standard env vars; default to local collector (OTLP HTTP).
+    // Note: OTLP endpoints should use TLS (https://) in production environments to secure telemetry transmission.
     otlpTracesEndpoint:
       process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT ||
       (process.env.OTEL_EXPORTER_OTLP_ENDPOINT

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,12 +2,21 @@ import pino from "pino";
 import { Config } from "./config";
 import { sanitizeError } from "./utils/sanitize";
 
+// Redacts sensitive tokens, then hands Errors to pino's standard serializer so the
+// message and stack survive JSON serialization (Error's own fields are non-enumerable).
+export const sanitizingErrorSerializer = (value: unknown) => {
+  const sanitized = sanitizeError(value);
+  return sanitized instanceof Error
+    ? pino.stdSerializers.err(sanitized)
+    : sanitized;
+};
+
 // Create logger configuration based on environment
 const pinoConfig = {
   level: Config.nodeEnv === "test" ? "silent" : "info",
   serializers: {
-    err: sanitizeError,
-    error: sanitizeError,
+    err: sanitizingErrorSerializer,
+    error: sanitizingErrorSerializer,
   },
   ...(Config.nodeEnv === "production"
     ? {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,9 +1,14 @@
 import pino from "pino";
 import { Config } from "./config";
+import { sanitizeError } from "./utils/sanitize";
 
 // Create logger configuration based on environment
 const pinoConfig = {
   level: Config.nodeEnv === "test" ? "silent" : "info",
+  serializers: {
+    err: sanitizeError,
+    error: sanitizeError,
+  },
   ...(Config.nodeEnv === "production"
     ? {
         // Production: JSON format for structured logging

--- a/src/routes/screenshot.ts
+++ b/src/routes/screenshot.ts
@@ -7,6 +7,7 @@ import { generateMetabaseEmbedUrl } from "../metabase";
 import { authenticateToken } from "../middleware/auth";
 import { screenshotRateLimiter } from "../middleware/rateLimiter";
 import { logger } from "../logger";
+import { sanitizeError } from "../utils/sanitize";
 import {
   screenshotRequests,
   concurrentRequests,
@@ -103,7 +104,7 @@ router.post(
     } catch (error) {
       screenshotRequests.inc({ status: "error" });
       logger.error(
-        { error, questionId: req.body.questionId },
+        { error: sanitizeError(error), questionId: req.body?.questionId },
         "Screenshot error",
       );
       res.status(500).json({

--- a/src/services/screenshot.ts
+++ b/src/services/screenshot.ts
@@ -11,6 +11,7 @@ import {
 import { tracingUtils } from "../tracing";
 import { logger } from "../logger";
 import { Config } from "../config";
+import { redactSensitiveInfo } from "../utils/sanitize";
 
 export class ScreenshotService {
   private browser: Browser | null = null;
@@ -138,7 +139,7 @@ export class ScreenshotService {
                                 selector: ".LoadingSpinner",
                                 state: "hidden",
                                 timeout: spinnerHiddenTimeout,
-                                error: error.message,
+                                error: redactSensitiveInfo(error.message),
                               },
                               "LoadingSpinner wait timeout - continuing",
                             );
@@ -160,7 +161,7 @@ export class ScreenshotService {
                               selector:
                                 "svg, canvas, .visualization, .DashCard",
                               timeout: vizContentTimeout,
-                              error: error.message,
+                              error: redactSensitiveInfo(error.message),
                             },
                             "Visualization elements not found in time - continuing",
                           );
@@ -172,7 +173,7 @@ export class ScreenshotService {
                   );
                 },
                 {
-                  "page.url": embedUrl,
+                  "request.questionId": request.questionId,
                   "page.selector": "div[data-testid=embed-frame]",
                 },
               );

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -9,6 +9,7 @@ import {
 } from "@opentelemetry/semantic-conventions";
 import { Config } from "./config";
 import packageJson from "../package.json";
+import { redactSensitiveInfo } from "./utils/sanitize";
 
 // Initialize OpenTelemetry
 export function initializeTracing() {
@@ -83,16 +84,21 @@ export const tracingUtils = {
           span.setStatus({ code: SpanStatusCode.OK });
           return result;
         } catch (error) {
+          const sanitizedMessage =
+            error instanceof Error
+              ? redactSensitiveInfo(error.message)
+              : redactSensitiveInfo(String(error));
+
           span.setStatus({
             code: SpanStatusCode.ERROR,
-            message: error instanceof Error ? error.message : "Unknown error",
+            message: sanitizedMessage,
           });
 
           if (error instanceof Error) {
             span.setAttributes({
               "error.name": error.name,
-              "error.message": error.message,
-              "error.stack": error.stack || "",
+              "error.message": sanitizedMessage,
+              "error.stack": redactSensitiveInfo(error.stack || ""),
             });
           }
 

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -39,52 +39,52 @@ export function redactSensitiveInfo(input: string): string {
  * Sanitizes an error object or value by redacting sensitive tokens and URLs from its message and stack trace.
  */
 export function sanitizeError<T>(error: T): T {
-  if (!error) return error;
+  return sanitizeValue(error, new Map()) as T;
+}
 
-  if (error instanceof Error) {
-    const copy = new Error(redactSensitiveInfo(error.message));
-    copy.name = error.name;
-    if (error.stack) {
-      copy.stack = redactSensitiveInfo(error.stack);
+/**
+ * Recursive worker for sanitizeError. `seen` maps each already-visited source object to its
+ * sanitized copy, so circular references resolve to that copy instead of recursing forever.
+ */
+function sanitizeValue(value: unknown, seen: Map<object, unknown>): unknown {
+  if (!value) return value;
+
+  if (typeof value === "string") {
+    return redactSensitiveInfo(value);
+  }
+
+  if (typeof value !== "object") return value;
+
+  const visited = seen.get(value);
+  if (visited !== undefined) return visited;
+
+  if (value instanceof Error) {
+    // Preserve the prototype so the copy keeps its class (TypeError, etc.)
+    const copy = Object.create(Object.getPrototypeOf(value)) as Error;
+    seen.set(value, copy);
+    copy.message = redactSensitiveInfo(value.message);
+    copy.name = value.name;
+    if (value.stack) {
+      copy.stack = redactSensitiveInfo(value.stack);
     }
     // Copy any additional custom properties on the error object
-    const record = error as unknown as Record<string, unknown>;
-    for (const key of Object.keys(error)) {
-      const val = record[key];
-      if (typeof val === "string") {
-        (copy as unknown as Record<string, unknown>)[key] =
-          redactSensitiveInfo(val);
-      } else if (val && typeof val === "object") {
-        (copy as unknown as Record<string, unknown>)[key] = sanitizeError(val);
-      } else {
-        (copy as unknown as Record<string, unknown>)[key] = val;
-      }
+    const record = value as unknown as Record<string, unknown>;
+    const target = copy as unknown as Record<string, unknown>;
+    for (const key of Object.keys(value)) {
+      target[key] = sanitizeValue(record[key], seen);
     }
-    return copy as unknown as T;
+    return copy;
   }
 
-  if (typeof error === "string") {
-    return redactSensitiveInfo(error) as unknown as T;
-  }
-
-  if (typeof error === "object") {
-    try {
-      const record = error as Record<string, unknown>;
-      const copy = (Array.isArray(error) ? [] : {}) as Record<string, unknown>;
-      for (const [key, val] of Object.entries(record)) {
-        if (typeof val === "string") {
-          copy[key] = redactSensitiveInfo(val);
-        } else if (val && typeof val === "object") {
-          copy[key] = sanitizeError(val);
-        } else {
-          copy[key] = val;
-        }
-      }
-      return copy as unknown as T;
-    } catch {
-      return error;
+  try {
+    const record = value as Record<string, unknown>;
+    const copy = (Array.isArray(value) ? [] : {}) as Record<string, unknown>;
+    seen.set(value, copy);
+    for (const [key, val] of Object.entries(record)) {
+      copy[key] = sanitizeValue(val, seen);
     }
+    return copy;
+  } catch {
+    return value;
   }
-
-  return error;
 }

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,0 +1,90 @@
+/**
+ * Utility functions for redacting sensitive URLs, JWTs, and tokens from error messages, logs, and trace spans.
+ */
+
+/**
+ * Redacts sensitive tokens and URLs from strings (such as error messages, stack traces, log outputs).
+ * Specifically targets:
+ * - Metabase signed embed URLs containing tokens (e.g. /embed/question/<token> or /embed/dashboard/<token>)
+ * - Standalone JWT tokens (eyJ...)
+ * - Sensitive query parameters (e.g. token=..., access_token=..., secret=..., signature=..., X-Amz-Signature=...)
+ */
+export function redactSensitiveInfo(input: string): string {
+  if (!input) return input;
+
+  let sanitized = input;
+
+  // 1. Redact Metabase embed URL path tokens: /embed/(question|dashboard|card|pivot)/<token>
+  sanitized = sanitized.replace(
+    /(\/embed\/(?:question|dashboard|card|pivot)\/)[^\s"'#?]+/gi,
+    "$1[REDACTED]",
+  );
+
+  // 2. Redact standalone JWT tokens (eyJ... . eyJ... . ...)
+  sanitized = sanitized.replace(
+    /\beyJ[a-zA-Z0-9_-]+\.eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\b/g,
+    "[REDACTED]",
+  );
+
+  // 3. Redact sensitive query parameters in URLs
+  sanitized = sanitized.replace(
+    /([?&](?:token|access_token|secret|signature|X-Amz-Signature|X-Amz-Credential|auth|api_key|key)=)[^&\s"'#]+/gi,
+    "$1[REDACTED]",
+  );
+
+  return sanitized;
+}
+
+/**
+ * Sanitizes an error object or value by redacting sensitive tokens and URLs from its message and stack trace.
+ */
+export function sanitizeError<T>(error: T): T {
+  if (!error) return error;
+
+  if (error instanceof Error) {
+    const copy = new Error(redactSensitiveInfo(error.message));
+    copy.name = error.name;
+    if (error.stack) {
+      copy.stack = redactSensitiveInfo(error.stack);
+    }
+    // Copy any additional custom properties on the error object
+    const record = error as unknown as Record<string, unknown>;
+    for (const key of Object.keys(error)) {
+      const val = record[key];
+      if (typeof val === "string") {
+        (copy as unknown as Record<string, unknown>)[key] =
+          redactSensitiveInfo(val);
+      } else if (val && typeof val === "object") {
+        (copy as unknown as Record<string, unknown>)[key] = sanitizeError(val);
+      } else {
+        (copy as unknown as Record<string, unknown>)[key] = val;
+      }
+    }
+    return copy as unknown as T;
+  }
+
+  if (typeof error === "string") {
+    return redactSensitiveInfo(error) as unknown as T;
+  }
+
+  if (typeof error === "object") {
+    try {
+      const record = error as Record<string, unknown>;
+      const copy = (Array.isArray(error) ? [] : {}) as Record<string, unknown>;
+      for (const [key, val] of Object.entries(record)) {
+        if (typeof val === "string") {
+          copy[key] = redactSensitiveInfo(val);
+        } else if (val && typeof val === "object") {
+          copy[key] = sanitizeError(val);
+        } else {
+          copy[key] = val;
+        }
+      }
+      return copy as unknown as T;
+    } catch {
+      return error;
+    }
+  }
+
+  return error;
+}


### PR DESCRIPTION
## Summary

Adds a centralized sanitization utility to prevent leakage of signed Metabase embed URLs, JWT tokens, and other sensitive credentials (e.g. `X-Amz-Signature`, `X-Amz-Credential`) into logs, trace spans, and error responses.

## Changes

- **New `src/utils/sanitize.ts`**: `redactSensitiveInfo` redacts Metabase `/embed/{question|dashboard|card|pivot}/<token>` paths, standalone JWT tokens, and sensitive query parameters. `sanitizeError` recursively sanitizes error messages, stack traces, and nested object fields.
- **Logger** (`src/logger.ts`): registers `err` and `error` serializers so Pino redacts sensitive data in all log output.
- **Tracing** (`src/tracing.ts`): error status messages and span attributes (`error.message`, `error.stack`) are sanitized before being sent to OTLP.
- **Screenshot service & route** (`src/services/screenshot.ts`, `src/routes/screenshot.ts`): error messages logged during rendering are redacted; the trace span attribute now records `request.questionId` instead of the full signed embed URL.
- **Docs & config**: README, `.env.example`, `config.ts`, and copilot instructions document the tracing env vars and note that OTLP endpoints must use TLS in production.

## Testing

- Added `src/__tests__/sanitize.test.ts` covering Metabase embed URL tokens, standalone JWTs, sensitive query parameters, plain messages, and nested error objects.